### PR TITLE
Add support for interrupt pins

### DIFF
--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -1,7 +1,7 @@
 #include "Arduino.h"
 #include "Evebrain.h"
 #include "lib/DHT/DHTesp.h"
-
+#include "lib/Interrupts.h"
 
 DHTesp dht;
 CmdProcessor cmdProcessor;
@@ -23,10 +23,7 @@ WS2812B led(STATUS_LED_PIN);
 
 int frequencyHZ[] =  {NOTE_B0,NOTE_C1,NOTE_CS1,NOTE_D1,NOTE_DS1,NOTE_E1,NOTE_F1,NOTE_FS1,NOTE_G1,NOTE_GS1,NOTE_A1,NOTE_AS1,NOTE_B1,NOTE_C2,NOTE_CS2,NOTE_D2, NOTE_DS2,NOTE_E2,NOTE_F2,NOTE_FS2,NOTE_G2,NOTE_GS2,NOTE_A2,NOTE_AS2,NOTE_B2,NOTE_C3,NOTE_CS3,NOTE_D3,NOTE_DS3,NOTE_E3,NOTE_F3,NOTE_FS3,NOTE_G3,NOTE_GS3,NOTE_A3,NOTE_AS3,NOTE_B3,NOTE_C4,NOTE_CS4,NOTE_D4,NOTE_DS4,NOTE_E4,NOTE_F4,NOTE_FS4,NOTE_G4,NOTE_GS4,NOTE_A4,NOTE_AS4,NOTE_B4,NOTE_C5,NOTE_CS5,NOTE_D5,NOTE_DS5,NOTE_E5,NOTE_F5,NOTE_FS5,NOTE_G5,NOTE_GS5,NOTE_A5,NOTE_AS5,NOTE_B5,NOTE_C6,NOTE_CS6,NOTE_D6, NOTE_DS6,NOTE_E6,NOTE_F6,NOTE_FS6,NOTE_G6,NOTE_GS6,NOTE_A6,NOTE_AS6,NOTE_B6,NOTE_C7,NOTE_CS7,NOTE_D7,NOTE_DS7,NOTE_E7,NOTE_F7,NOTE_FS7,NOTE_G7,NOTE_GS7,NOTE_A7,NOTE_AS7,NOTE_B7,NOTE_C8,NOTE_CS8,NOTE_D8,NOTE_DS8};
 
-// These are declared here, because of the way they work with interrupts
-// For each notification, the MSbit is the state, and the rest of the bits are the pin number.
-volatile unsigned char interruptNotifications[10] = {0};
-volatile unsigned char numInterruptNotifications = 0;
+volatile PinStateStack pinStates;
 
 void handleWsMsg(char * msg){
   cmdProcessor.processMsg(msg);
@@ -374,8 +371,7 @@ void Evebrain::_digitalNotify(ArduinoJson::JsonObject &inJson, ArduinoJson::Json
   } else {
     // If succesfully added ISR to pin, report current pin's status.
     noInterrupts();
-    unsigned char interruptNotification = digitalRead(pin) << 7 | pin;
-    interruptNotifications[numInterruptNotifications++] = interruptNotification;
+    pinStates.push(PinState(pin, digitalRead(pin)));
     interrupts();
   }
 }
@@ -606,26 +602,9 @@ short Evebrain::digitalInput(byte pin){
   return digitalRead(pin);
 }
 
-#define MAKE_ISR_FOR_PIN(X)                                                        \
-  ICACHE_RAM_ATTR void pin##X##ISR()                                               \
-  {                                                                                \
-    if (numInterruptNotifications == sizeof(interruptNotifications))               \
-    {                                                                              \
-      return; /* don't add notification if buffer full*/                           \
-    }                                                                              \
-    else                                                                           \
-    {                                                                              \
-      unsigned char state = digitalRead((X)) == HIGH ? 1 : 0;                      \
-      unsigned char interruptNotification = state << 7 | (X);                      \
-      interruptNotifications[numInterruptNotifications++] = interruptNotification; \
-    }                                                                              \
-  }
-
-// Define the list of pins we can add an interrupt handler on
-#define INTERRUPTABLE_PINS X(4) X(14) X(12) X(13) X(0) X(2)
 
 // Create the ISRs
-#define X(pinNum) MAKE_ISR_FOR_PIN(pinNum)
+#define X(pinNum) MAKE_ISR_FOR_PIN(pinNum, pinStates)
 INTERRUPTABLE_PINS
 #undef X
 
@@ -973,20 +952,18 @@ void Evebrain::serialHandler(){
 }
 
 void Evebrain::digitalNotifyHandler() {
-  while (numInterruptNotifications > 0) {
+  while (pinStates.numberOfElements()) {
     // grab the interrupt notification and decrement the counter,
     // while ensuring that this is not interrupted.
     noInterrupts();
-    unsigned char currentNotification = interruptNotifications[numInterruptNotifications - 1];
-    numInterruptNotifications--;
+    PinState state = pinStates.pop();
     interrupts();
     // Send the pin change notification
     DynamicJsonBuffer outBuffer;
     JsonObject& outMsg = outBuffer.createObject();
-    unsigned char currentPin = currentNotification & 0x7F; // clear the MSbit, for the pin number
-    outMsg["msg"] = currentNotification >> 7; // grab the MSbit only, for the pin value
+    outMsg["msg"] = state.pinState;
     char notifyID[20];
-    snprintf(notifyID, sizeof(notifyID), "pin_%d_status", currentPin);
+    snprintf(notifyID, sizeof(notifyID), "pin_%d_status", state.pin);
     cmdProcessor.notify(notifyID, outMsg);
   }
 }

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -953,18 +953,20 @@ void Evebrain::serialHandler(){
 
 void Evebrain::digitalNotifyHandler() {
   while (pinStates.numberOfElements()) {
-    // grab the interrupt notification and decrement the counter,
-    // while ensuring that this is not interrupted.
+    // grab the interrupt notification, ensuring that this is not interrupted.
     noInterrupts();
     PinState state = pinStates.pop();
     interrupts();
-    // Send the pin change notification
-    DynamicJsonBuffer outBuffer;
-    JsonObject& outMsg = outBuffer.createObject();
-    outMsg["msg"] = state.pinState;
-    char notifyID[20];
-    snprintf(notifyID, sizeof(notifyID), "pin_%d_status", state.pin);
-    cmdProcessor.notify(notifyID, outMsg);
+    if (state != PinState::invalid) {
+      //digitalWrite(14, state.pinState);
+      // Send the pin change notification
+      DynamicJsonBuffer outBuffer;
+      JsonObject &outMsg = outBuffer.createObject();
+      outMsg["msg"] = state.pinState;
+      char notifyID[20];
+      snprintf(notifyID, sizeof(notifyID), "pin_%d_status", state.pin);
+      cmdProcessor.notify(notifyID, outMsg);
+    }
   }
 }
 

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -182,6 +182,7 @@ void Evebrain::initCmds(){
   cmdProcessor.addCmd("analogInput",      &Evebrain::_analogInput,      true);
   cmdProcessor.addCmd("readSensors",      &Evebrain::_readSensors,      false);
   cmdProcessor.addCmd("digitalInput",     &Evebrain::_digitalInput,     true);
+  cmdProcessor.addCmd("digitalNotify",    &Evebrain::_digitalNotify,    true);
   cmdProcessor.addCmd("gpio_on",          &Evebrain::_gpio_on,          true);
   cmdProcessor.addCmd("gpio_off",         &Evebrain::_gpio_off,         true);
   cmdProcessor.addCmd("gpio_pwm_16",      &Evebrain::_gpio_pwm_16,      true);
@@ -355,6 +356,10 @@ void Evebrain::_gpio_on(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonObject
 
 void Evebrain::_digitalInput(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonObject &outJson ) {
   outJson["msg"] = digitalInput(atoi(inJson["arg"].asString()));
+}
+
+void Evebrain::_digitalNotify(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonObject &outJson ) {
+  digitalNotify(atoi(inJson["arg"].asString()));
 }
 
 void Evebrain::_gpio_pwm_16(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonObject &outJson ) {
@@ -571,8 +576,24 @@ void Evebrain::distanceSensor(){
 
 short Evebrain::digitalInput(byte pin){
   digitalWrite(pin, LOW);
-  pinMode(pin, INPUT); 
+  pinMode(pin, INPUT);
   return digitalRead(pin);
+}
+
+//volatile byte notifyPin;
+void ICACHE_RAM_ATTR notifyChange();
+
+void notifyChange() {
+  DynamicJsonBuffer outBuffer;
+  JsonObject& outMsg = outBuffer.createObject();
+  outMsg["msg"] = digitalRead(4);
+  cmdProcessor.notify("pin_change", outMsg);
+}
+
+void Evebrain::digitalNotify(byte pin) {
+  //notifyPin = pin;
+  pinMode(4, INPUT);
+  attachInterrupt(digitalPinToInterrupt(4), notifyChange, CHANGE); 
 }
 
 void Evebrain::gpio_on(byte pin){

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -606,46 +606,36 @@ short Evebrain::digitalInput(byte pin){
     cmdProcessor.notify("pin_change", outMsg);     \
   }                                                \
 
-#define CASE_ATTACH_INTERRUPT_PIN(X)    \
-  case (X): \
-    pinMode( (X), INPUT); \
-    attachInterrupt(digitalPinToInterrupt( (X) ), pin##X##ISR, CHANGE);\
-    return 0; \
+// Define the list of pins we can add an interrupt handler on
+#define INTERRUPTABLE_PINS X(4) X(14) X(12) X(13) X(0) X(2)
 
 // Create the ISRs
-MAKE_ISR_FOR_PIN(4)
-MAKE_ISR_FOR_PIN(14)
-MAKE_ISR_FOR_PIN(12)
-MAKE_ISR_FOR_PIN(13)
-MAKE_ISR_FOR_PIN(0)
-MAKE_ISR_FOR_PIN(2)
+#define X(pinNum) MAKE_ISR_FOR_PIN(pinNum)
+INTERRUPTABLE_PINS
+#undef X
 
 int Evebrain::digitalNotify(byte pin) {
   switch(pin) {
-    CASE_ATTACH_INTERRUPT_PIN(4)
-    CASE_ATTACH_INTERRUPT_PIN(14)
-    CASE_ATTACH_INTERRUPT_PIN(12)
-    CASE_ATTACH_INTERRUPT_PIN(13)
-    CASE_ATTACH_INTERRUPT_PIN(0)
-    CASE_ATTACH_INTERRUPT_PIN(2)
+    #define X(pinNum)                                                         \
+    case (pinNum):                                                            \
+      pinMode( (pinNum), INPUT);                                              \
+      attachInterrupt(digitalPinToInterrupt( (pinNum) ), pin##pinNum##ISR, CHANGE);\
+      return 0;
+    INTERRUPTABLE_PINS
+    #undef X
     default:
       return 1; // signal error
   }
 }
 
-#define CASE_DETACH_INTERRUPT_PIN(X)               \
-  case (X):                                        \
-    detachInterrupt(digitalPinToInterrupt( (X) )); \
-    return 0;                                      \
-
 int Evebrain::digitalStopNotify(byte pin) {
   switch(pin) {
-    CASE_DETACH_INTERRUPT_PIN(4)
-    CASE_DETACH_INTERRUPT_PIN(14)
-    CASE_DETACH_INTERRUPT_PIN(12)
-    CASE_DETACH_INTERRUPT_PIN(13)
-    CASE_DETACH_INTERRUPT_PIN(0)
-    CASE_DETACH_INTERRUPT_PIN(2)
+    #define X(pinNum)                                     \
+    case (pinNum):                                        \
+      detachInterrupt(digitalPinToInterrupt( (pinNum) )); \
+      return 0;
+    INTERRUPTABLE_PINS
+    #undef X
     default:
       return 1; // signal error
   }

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -365,11 +365,18 @@ void Evebrain::_digitalInput(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonO
 }
 
 void Evebrain::_digitalNotify(ArduinoJson::JsonObject &inJson, ArduinoJson::JsonObject &outJson ) {
-  int code = digitalNotify(atoi(inJson["arg"].asString()));
+  unsigned char pin = atoi(inJson["arg"].asString());
+  int code = digitalNotify(pin);
   // signal error condition to cmd processor
   if (code) {
     outJson["status"] = "error";
     outJson["msg"] = "Cannot be notified about changes to that pin";
+  } else {
+    // If succesfully added ISR to pin, report current pin's status.
+    noInterrupts();
+    unsigned char interruptNotification = digitalRead(pin) << 7 | pin;
+    interruptNotifications[numInterruptNotifications++] = interruptNotification;
+    interrupts();
   }
 }
 

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -23,7 +23,7 @@ WS2812B led(STATUS_LED_PIN);
 
 int frequencyHZ[] =  {NOTE_B0,NOTE_C1,NOTE_CS1,NOTE_D1,NOTE_DS1,NOTE_E1,NOTE_F1,NOTE_FS1,NOTE_G1,NOTE_GS1,NOTE_A1,NOTE_AS1,NOTE_B1,NOTE_C2,NOTE_CS2,NOTE_D2, NOTE_DS2,NOTE_E2,NOTE_F2,NOTE_FS2,NOTE_G2,NOTE_GS2,NOTE_A2,NOTE_AS2,NOTE_B2,NOTE_C3,NOTE_CS3,NOTE_D3,NOTE_DS3,NOTE_E3,NOTE_F3,NOTE_FS3,NOTE_G3,NOTE_GS3,NOTE_A3,NOTE_AS3,NOTE_B3,NOTE_C4,NOTE_CS4,NOTE_D4,NOTE_DS4,NOTE_E4,NOTE_F4,NOTE_FS4,NOTE_G4,NOTE_GS4,NOTE_A4,NOTE_AS4,NOTE_B4,NOTE_C5,NOTE_CS5,NOTE_D5,NOTE_DS5,NOTE_E5,NOTE_F5,NOTE_FS5,NOTE_G5,NOTE_GS5,NOTE_A5,NOTE_AS5,NOTE_B5,NOTE_C6,NOTE_CS6,NOTE_D6, NOTE_DS6,NOTE_E6,NOTE_F6,NOTE_FS6,NOTE_G6,NOTE_GS6,NOTE_A6,NOTE_AS6,NOTE_B6,NOTE_C7,NOTE_CS7,NOTE_D7,NOTE_DS7,NOTE_E7,NOTE_F7,NOTE_FS7,NOTE_G7,NOTE_GS7,NOTE_A7,NOTE_AS7,NOTE_B7,NOTE_C8,NOTE_CS8,NOTE_D8,NOTE_DS8};
 
-volatile PinStateStack pinStates;
+volatile PinStateQueue pinStates;
 
 void handleWsMsg(char * msg){
   cmdProcessor.processMsg(msg);
@@ -958,7 +958,6 @@ void Evebrain::digitalNotifyHandler() {
     PinState state = pinStates.pop();
     interrupts();
     if (state != PinState::invalid) {
-      //digitalWrite(14, state.pinState);
       // Send the pin change notification
       DynamicJsonBuffer outBuffer;
       JsonObject &outMsg = outBuffer.createObject();

--- a/src/Evebrain.cpp
+++ b/src/Evebrain.cpp
@@ -976,11 +976,11 @@ void Evebrain::digitalNotifyHandler() {
     // Send the pin change notification
     DynamicJsonBuffer outBuffer;
     JsonObject& outMsg = outBuffer.createObject();
-    JsonObject& outMsgContents = outBuffer.createObject();
-    outMsgContents["pin"] = currentNotification & 0x7F; // clear the MSbit
-    outMsgContents["state"] = currentNotification >> 7; // grab the MSbit only
-    outMsg["msg"] = outMsgContents;
-    cmdProcessor.notify("pin_change", outMsg);
+    unsigned char currentPin = currentNotification & 0x7F; // clear the MSbit, for the pin number
+    outMsg["msg"] = currentNotification >> 7; // grab the MSbit only, for the pin value
+    char notifyID[20];
+    snprintf(notifyID, sizeof(notifyID), "pin_%d_status", currentPin);
+    cmdProcessor.notify(notifyID, outMsg);
   }
 }
 

--- a/src/Evebrain.h
+++ b/src/Evebrain.h
@@ -139,6 +139,7 @@ class Evebrain {
     void version(char);
     void initCmds();
     void serialHandler();
+    void digitalNotifyHandler();
     void _version(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _ping(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _uptime(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);

--- a/src/Evebrain.h
+++ b/src/Evebrain.h
@@ -98,7 +98,8 @@ class Evebrain {
     void beep(int,int);
     short analogInput();
     short digitalInput(byte);
-    void digitalNotify(byte);
+    void digitalNotify(byte); // These two functions deal with the 
+    void digitalStopNotify(byte); // interrupt notifications
     void gpio_on(byte);
     void gpio_off(byte);
     void gpio_pwm(byte, byte);
@@ -167,6 +168,7 @@ class Evebrain {
     void _humidity(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _digitalInput(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _digitalNotify(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
+    void _digitalStopNotify(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_on(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_off(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_pwm_16(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);

--- a/src/Evebrain.h
+++ b/src/Evebrain.h
@@ -98,8 +98,8 @@ class Evebrain {
     void beep(int,int);
     short analogInput();
     short digitalInput(byte);
-    void digitalNotify(byte); // These two functions deal with the 
-    void digitalStopNotify(byte); // interrupt notifications
+    int digitalNotify(byte); // These two functions deal with the 
+    int digitalStopNotify(byte); // interrupt notifications
     void gpio_on(byte);
     void gpio_off(byte);
     void gpio_pwm(byte, byte);

--- a/src/Evebrain.h
+++ b/src/Evebrain.h
@@ -98,6 +98,7 @@ class Evebrain {
     void beep(int,int);
     short analogInput();
     short digitalInput(byte);
+    void digitalNotify(byte);
     void gpio_on(byte);
     void gpio_off(byte);
     void gpio_pwm(byte, byte);
@@ -165,6 +166,7 @@ class Evebrain {
     void _temperature(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _humidity(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _digitalInput(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
+    void _digitalNotify(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_on(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_off(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);
     void _gpio_pwm_16(ArduinoJson::JsonObject &, ArduinoJson::JsonObject &);

--- a/src/lib/CmdProcessor.cpp
+++ b/src/lib/CmdProcessor.cpp
@@ -66,7 +66,13 @@ boolean CmdProcessor::processMsg(char * msg){
     if(cmd_num >= 0){
       if(_cmds[cmd_num].immediate){
         (_m->*(_cmds[cmd_num].func))(inMsg, outMsg);
-        sendResponse("complete", outMsg, *id);
+        // kludge to allow an error condition to notify Snap
+        if (outMsg.containsKey("status") &&
+            strcmp(outMsg["status"], "error") == 0) {
+          sendResponse("error", outMsg, *id);
+        } else {
+          sendResponse("complete", outMsg, *id);
+        }
       }else{
         if(in_process){
           // the previous command hasn't finished, send an error

--- a/src/lib/Interrupts.cpp
+++ b/src/lib/Interrupts.cpp
@@ -9,17 +9,32 @@ bool PinStateStack::push(PinState state) volatile {
         return false;
     } else {
         unsigned char charState = state.pin + (state.pinState << 7);
-        stack[numElements++] = charState;
+        stack[numElements] = charState;
+        numElements++;
         return true;
     }
 }
 PinState PinStateStack::pop() volatile {
-    unsigned char pinState = stack[--numElements];
-    return PinState(pinState & 0x7F, pinState >> 7);
+    if (numElements > 0) {
+        numElements--;
+        unsigned char pinState = stack[numElements];
+        return PinState(pinState & 0x7F, pinState >> 7);
+    } else {
+        return PinState::invalid;
+    }
 }
 int PinStateStack::numberOfElements() volatile {
     return numElements;
 }
 bool PinStateStack::full() volatile {
     return numElements == STACK_SIZE;
+}
+
+PinState PinState::invalid(127, 0);
+bool PinState::operator==(const PinState& other) {
+    return pin == other.pin && pinState == other.pinState;
+}
+
+bool PinState::operator!=(const PinState& other) {
+    return !(*this == other);
 }

--- a/src/lib/Interrupts.cpp
+++ b/src/lib/Interrupts.cpp
@@ -1,32 +1,35 @@
 #include "Interrupts.h"
 
-PinStateStack::PinStateStack() {
+PinStateQueue::PinStateQueue() {
 
 }
 
-bool PinStateStack::push(PinState state) volatile {
+bool PinStateQueue::push(PinState state) volatile {
     if (full()) {
         return false;
     } else {
         unsigned char charState = state.pin + (state.pinState << 7);
-        stack[numElements] = charState;
-        numElements++;
+        stack[numElements++] = charState;
         return true;
     }
 }
-PinState PinStateStack::pop() volatile {
+PinState PinStateQueue::pop() volatile {
     if (numElements > 0) {
+        unsigned char pinState = stack[0];
+        // Now, copy everything down one slot
+        for (int i = 1; i < numElements; i++) {
+            stack[i-1] = stack[i];
+        }
         numElements--;
-        unsigned char pinState = stack[numElements];
         return PinState(pinState & 0x7F, pinState >> 7);
     } else {
         return PinState::invalid;
     }
 }
-int PinStateStack::numberOfElements() volatile {
+int PinStateQueue::numberOfElements() volatile {
     return numElements;
 }
-bool PinStateStack::full() volatile {
+bool PinStateQueue::full() volatile {
     return numElements == STACK_SIZE;
 }
 

--- a/src/lib/Interrupts.cpp
+++ b/src/lib/Interrupts.cpp
@@ -1,0 +1,25 @@
+#include "Interrupts.h"
+
+PinStateStack::PinStateStack() {
+
+}
+
+bool PinStateStack::push(PinState state) volatile {
+    if (full()) {
+        return false;
+    } else {
+        unsigned char charState = state.pin + (state.pinState << 7);
+        stack[numElements++] = charState;
+        return true;
+    }
+}
+PinState PinStateStack::pop() volatile {
+    unsigned char pinState = stack[--numElements];
+    return PinState(pinState & 0x7F, pinState >> 7);
+}
+int PinStateStack::numberOfElements() volatile {
+    return numElements;
+}
+bool PinStateStack::full() volatile {
+    return numElements == STACK_SIZE;
+}

--- a/src/lib/Interrupts.h
+++ b/src/lib/Interrupts.h
@@ -18,24 +18,27 @@ class PinState {
 
 #define STACK_SIZE 10
 
-class PinStateStack {
+/**
+ * Implements a queue for pin states. Is O(1) to insert, O(n)
+ * to remove, where n is the number of elements in the queue.
+ */
+class PinStateQueue {
 public:
-    PinStateStack();
+    PinStateQueue();
     bool push(PinState state) volatile;
     PinState pop() volatile;
     int numberOfElements() volatile;
     bool full() volatile;
 private:
     // NOTE: each element of the stack has the pin number, and the MSbit is the state of the pin 
-    volatile unsigned stack[STACK_SIZE];
-    volatile unsigned char numElements = 0;
+    volatile unsigned char stack[STACK_SIZE];
+    volatile int numElements = 0;
 };
 
 #define MAKE_ISR_FOR_PIN(X, NOTIFYSTACK)                         \
   ICACHE_RAM_ATTR void pin##X##ISR()                             \
   {                                                              \
     int pinValue = digitalRead((X));                             \
-    /*digitalWrite(12, pinValue);*/                                  \
     (NOTIFYSTACK).push(PinState((X), pinValue == HIGH ? 1 : 0)); \
   }
 

--- a/src/lib/Interrupts.h
+++ b/src/lib/Interrupts.h
@@ -1,0 +1,44 @@
+#ifndef __INTERRUPTS_H__
+#define __INTERRUPTS_H__
+
+#include "Arduino.h"
+
+// Define the list of pins we can add an interrupt handler on
+#define INTERRUPTABLE_PINS X(4) X(14) X(12) X(13) X(0) X(2)
+
+class PinState {
+    public:
+    PinState(unsigned char pin, unsigned char pinState): pin(pin), pinState(pinState) {}
+    PinState(): pin(0), pinState(0) {}
+    unsigned char pin, pinState;
+};
+
+#define STACK_SIZE 10
+
+class PinStateStack {
+public:
+    PinStateStack();
+    bool push(PinState state) volatile;
+    PinState pop() volatile;
+    int numberOfElements() volatile;
+    bool full() volatile;
+private:
+    // NOTE: each element of the stack has the pin number, and the MSbit is the state of the pin 
+    volatile unsigned stack[STACK_SIZE];
+    volatile unsigned char numElements = 0;
+};
+
+#define MAKE_ISR_FOR_PIN(X, NOTIFYSTACK)                                           \
+  ICACHE_RAM_ATTR void pin##X##ISR()                                               \
+  {                                                                                \
+    if ((NOTIFYSTACK).full())                                                      \
+    {                                                                              \
+      return; /* don't add notification if buffer full*/                           \
+    }                                                                              \
+    else                                                                           \
+    {                                                                              \
+      (NOTIFYSTACK).push( PinState((X), digitalRead((X)) == HIGH ? 1 : 0));        \
+    }                                                                              \
+  }
+
+#endif

--- a/src/lib/Interrupts.h
+++ b/src/lib/Interrupts.h
@@ -10,7 +10,10 @@ class PinState {
     public:
     PinState(unsigned char pin, unsigned char pinState): pin(pin), pinState(pinState) {}
     PinState(): pin(0), pinState(0) {}
+    bool operator==(const PinState& other);
+    bool operator!=(const PinState& other);
     unsigned char pin, pinState;
+    static PinState invalid;
 };
 
 #define STACK_SIZE 10
@@ -28,17 +31,12 @@ private:
     volatile unsigned char numElements = 0;
 };
 
-#define MAKE_ISR_FOR_PIN(X, NOTIFYSTACK)                                           \
-  ICACHE_RAM_ATTR void pin##X##ISR()                                               \
-  {                                                                                \
-    if ((NOTIFYSTACK).full())                                                      \
-    {                                                                              \
-      return; /* don't add notification if buffer full*/                           \
-    }                                                                              \
-    else                                                                           \
-    {                                                                              \
-      (NOTIFYSTACK).push( PinState((X), digitalRead((X)) == HIGH ? 1 : 0));        \
-    }                                                                              \
+#define MAKE_ISR_FOR_PIN(X, NOTIFYSTACK)                         \
+  ICACHE_RAM_ATTR void pin##X##ISR()                             \
+  {                                                              \
+    int pinValue = digitalRead((X));                             \
+    /*digitalWrite(12, pinValue);*/                                  \
+    (NOTIFYSTACK).push(PinState((X), pinValue == HIGH ? 1 : 0)); \
   }
 
 #endif


### PR DESCRIPTION
Can 'subscribe' to a pin with digitalNiotify, and stop with the command digitalStopNotify. When a subscription is started or the pin changes state, a notify is sent with the id "pin_X_status" id.
If one attempts to start a subscription with a pin that is not marked for it, an error message is sent.